### PR TITLE
Fixed 'intial' to 'initial'

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -17,7 +17,7 @@ project:
         - file: notebooks/how-to-cite.md
     - title: Introduction
       children:
-        - file: notebooks/intro/initial_concepts
+        - file: notebooks/intro/initial_concepts.md
         - file: notebooks/intro/crash_course.ipynb
     - title: Dynamical Background
       children:

--- a/notebooks/intro/initial_concepts.md
+++ b/notebooks/intro/initial_concepts.md
@@ -1,0 +1,3 @@
+# Initial Concepts
+
+...

--- a/notebooks/intro/intial_concepts.md
+++ b/notebooks/intro/intial_concepts.md
@@ -1,3 +1,0 @@
-# Intial Concepts
-
-...


### PR DESCRIPTION
"Initial" was misspelled everywhere. Opening this PR to merge the fix so I don't have to adjust it every time.
