### PR TITLE
Add some cross-references for equations

### DIFF
--- a/notebooks/appendix/finite_differencing.md
+++ b/notebooks/appendix/finite_differencing.md
@@ -2,7 +2,7 @@
 
 Here we compile the standard finite difference schemes of various orders on uniform grids.
 
-Consider the derivative $du/dx$ of a function $u(x)$, where $x$ can be any independent variable (e.g., time, space, etc.). Finite-difference approximations are used to represent the continuous function $u(x)$ by a set of discrete points $u^n$ at evenly spaced intervals, where $n$ is the index of the point in the grid. The spacing between these points is denoted as $\Delta x$.
+Consider the derivative $du/dx$ of a function $u(x)$, where $x$ can be any independent variable (e.g., time, space, etc.). Finite-difference approximations are used to represent the continuous function $u(x)$ by a set of discrete points $u_n$ at evenly spaced intervals, where $n$ is the index of the point in the grid. The spacing between these points is denoted as $\Delta x$.
 
 :::{figure} 1d-grid.png
 :label: 1d-grid
@@ -27,25 +27,25 @@ The notation $\mathcal{O}(\cdot)$, known as Big $\mathcal{O}$ notation, describe
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:forward_first_o1}\frac{u^{n+1} - u^n}{\Delta x}$$ | $$\label{eq:forward_first_o2}\frac{-u^{n+2} + 4u^{n+1} - 3u^n}{2\Delta x}$$ |
+| $$\label{forward_first_o1}\frac{u_{n+1} - u_n}{\Delta x}$$ | $$\label{forward_first_o2}\frac{-u_{n+2} + 4u_{n+1} - 3u_n}{2\Delta x}$$ |
 
 ### Second Derivative $(\frac{\partial^2 u}{\partial x^2})$
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:forward_second_o1}\frac{u^{n+2} - 2u^{n+1} + u^n}{\Delta x^2}$$ | $$\label{eq:forward_second_o2}\frac{-u^{n+3} + 4u^{n+2} - 5u^{n+1} + 2u^n}{\Delta x^2}$$ |
+| $$\label{forward_second_o1}\frac{u_{n+2} - 2u_{n+1} + u_n}{\Delta x^2}$$ | $$\label{forward_second_o2}\frac{-u_{n+3} + 4u_{n+2} - 5u_{n+1} + 2u_n}{\Delta x^2}$$ |
 
 ### Third Derivative $(\frac{\partial^3 u}{\partial x^3})$
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:forward_third_o1}\frac{u^{n+3} - 3u^{n+2} + 3u^{n+1} - u^n}{\Delta x^3}$$ | $$\label{eq:forward_third_o2}\frac{-3u^{n+4} + 14u^{n+3} - 24u^{n+2} + 18u^{n+1} - 5u^n}{2\Delta x^3}$$ |
+| $$\label{forward_third_o1}\frac{u_{n+3} - 3u_{n+2} + 3u_{n+1} - u_n}{\Delta x^3}$$ | $$\label{forward_third_o2}\frac{-3u_{n+4} + 14u_{n+3} - 24u_{n+2} + 18u_{n+1} - 5u_n}{2\Delta x^3}$$ |
 
 ### Fourth Derivative $(\frac{\partial^4 u}{\partial x^4})$
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:forward_fourth_o1}\frac{u^{n+4} - 4u^{n+3} + 6u^{n+2} - 4u^{n+1} + u^n}{\Delta x^4}$$ | $$\label{eq:forward_fourth_o2}\frac{-2u^{n+5} + 11u^{n+4} - 24u^{n+3} + 26u^{n+2} - 14u^{n+1} + 3u^n}{\Delta x^4}$$ |
+| $$\label{forward_fourth_o1}\frac{u_{n+4} - 4u_{n+3} + 6u_{n+2} - 4u_{n+1} + u_n}{\Delta x^4}$$ | $$\label{forward_fourth_o2}\frac{-2u_{n+5} + 11u_{n+4} - 24u_{n+3} + 26u_{n+2} - 14u_{n+1} + 3u_n}{\Delta x^4}$$ |
 
 ---
 
@@ -55,25 +55,25 @@ The notation $\mathcal{O}(\cdot)$, known as Big $\mathcal{O}$ notation, describe
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:backward_first_o1}\frac{u^n - u^{n-1}}{\Delta x}$$|$$\label{eq:backward_first_o2}\frac{3u^n - 4u^{n-1} + u^{n-2}}{2\Delta x}$$ |
+| $$\label{backward_first_o1}\frac{u_n - u_{n-1}}{\Delta x}$$|$$\label{backward_first_o2}\frac{3u_n - 4u_{n-1} + u_{n-2}}{2\Delta x}$$ |
 
 ### Second Derivative $(\frac{\partial^2 u}{\partial x^2})$
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:backward_second_o1}\frac{u^n - 2u^{n-1} + u^{n-2}}{\Delta x^2}$$|$$\label{eq:backward_second_o2}\frac{2u^n - 5u^{n-1} + 4u^{n-2} - u^{n-3}}{\Delta x^2}$$ |
+| $$\label{backward_second_o1}\frac{u_n - 2u_{n-1} + u_{n-2}}{\Delta x^2}$$|$$\label{backward_second_o2}\frac{2u_n - 5u_{n-1} + 4u_{n-2} - u_{n-3}}{\Delta x^2}$$ |
 
 ### Third Derivative $(\frac{\partial^3 u}{\partial x^3})$
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:backward_third_o1}\frac{u^n - 3u^{n-1} + 3u^{n-2} - u^{n-3}}{\Delta x^3}$$|$$\label{eq:backward_third_o2}\frac{5u^n - 18u^{n-1} + 24u^{n-2} - 14u^{n-3} + 3u^{n-4}}{2\Delta x^3}$$ |
+| $$\label{backward_third_o1}\frac{u_n - 3u_{n-1} + 3u_{n-2} - u_{n-3}}{\Delta x^3}$$|$$\label{backward_third_o2}\frac{5u_n - 18u_{n-1} + 24u_{n-2} - 14u_{n-3} + 3u_{n-4}}{2\Delta x^3}$$ |
 
 ### Fourth Derivative $(\frac{\partial^4 u}{\partial x^4})$
 
 | $\mathcal{O}(\Delta x)$ | $\mathcal{O}(\Delta x^2)$ |
 | :---: | :---: |
-| $$\label{eq:backward_fourth_o1}\frac{u^n - 4u^{n-1} + 6u^{n-2} - 4u^{n-3} + u^{n-4}}{\Delta x^4}$$|$$\label{eq:backward_fourth_o2}\frac{3u^n - 14u^{n-1} + 26u^{n-2} - 24u^{n-3} + 11u^{n-4} - 2u^{n-5}}{\Delta x^4}$$ |
+| $$\label{backward_fourth_o1}\frac{u_n - 4u_{n-1} + 6u_{n-2} - 4u_{n-3} + u_{n-4}}{\Delta x^4}$$|$$\label{backward_fourth_o2}\frac{3u_n - 14u_{n-1} + 26u_{n-2} - 24u_{n-3} + 11u_{n-4} - 2u_{n-5}}{\Delta x^4}$$ |
 
 ---
 
@@ -83,22 +83,22 @@ The notation $\mathcal{O}(\cdot)$, known as Big $\mathcal{O}$ notation, describe
 
 | $\mathcal{O}(\Delta x^2)$ | $\mathcal{O}(\Delta x^4)$ |
 | :---: | :---: |
-| $$\label{eq:central_first_o2}\frac{u^{n+1} - u^{n-1}}{2\Delta x}$$|$$\label{eq:central_first_o4}\frac{-u^{n+2} + 8u^{n+1} - 8u^{n-1} + u^{n-2}}{12\Delta x}$$ |
+| $$\label{central_first_o2}\frac{u_{n+1} - u_{n-1}}{2\Delta x}$$|$$\label{central_first_o4}\frac{-u_{n+2} + 8u_{n+1} - 8u_{n-1} + u_{n-2}}{12\Delta x}$$ |
 
 ### Second Derivative $(\frac{\partial^2 u}{\partial x^2})$
 
 | $\mathcal{O}(\Delta x^2)$ | $\mathcal{O}(\Delta x^4)$ |
 | :---: | :---: |
-| $$\label{eq:central_second_o2}\frac{u^{n+1} - 2u^n + u^{n-1}}{\Delta x^2}$$|$$\label{eq:central_second_o4}\frac{-u^{n+2} + 16u^{n+1} - 30u^n + 16u^{n-1} - u^{n-2}}{12\Delta x^2}$$ |
+| $$\label{central_second_o2}\frac{u_{n+1} - 2u_n + u_{n-1}}{\Delta x^2}$$|$$\label{central_second_o4}\frac{-u_{n+2} + 16u_{n+1} - 30u_n + 16u_{n-1} - u_{n-2}}{12\Delta x^2}$$ |
 
 ### Third Derivative $(\frac{\partial^3 u}{\partial x^3})$
 
 | $\mathcal{O}(\Delta x^2)$ | $\mathcal{O}(\Delta x^4)$ |
 | :---: | :---: |
-| $$\label{eq:central_third_o2}\frac{u^{n+2} + 2u^{n+1} - 2u^{n-1} - u^{n-2}}{2\Delta x^3}$$|$$\label{eq:central_third_o4}\frac{-u^{n+3} + 8u^{n+2} - 13u^{n+1} + 13u^{n-1} - 8u^{n-2} + u^{n-3}}{8\Delta x^3}$$ |
+| $$\label{central_third_o2}\frac{u_{n+2} + 2u_{n+1} - 2u_{n-1} - u_{n-2}}{2\Delta x^3}$$|$$\label{central_third_o4}\frac{-u_{n+3} + 8u_{n+2} - 13u_{n+1} + 13u_{n-1} - 8u_{n-2} + u_{n-3}}{8\Delta x^3}$$ |
 
 ### Fourth Derivative $(\frac{\partial^4 u}{\partial x^4})$
 
 | $\mathcal{O}(\Delta x^2)$ | $\mathcal{O}(\Delta x^4)$ |
 | :---: | :---: |
-| $$\label{eq:central_fourth_o2}\frac{u^{n+2} - 4u^{n+1} + 6u^n - 4u^{n-1} + u^{n-2}}{\Delta x^4}$$|$$\label{eq:central_fourth_o4}\frac{-u^{n+3} + 12u^{n+2} - 39u^{n+1} + 56u^n - 39u^{n-1} + 12u^{n-2} - u^{n-3}}{6\Delta x^4}$$ |
+| $$\label{central_fourth_o2}\frac{u_{n+2} - 4u_{n+1} + 6u_n - 4u_{n-1} + u_{n-2}}{\Delta x^4}$$|$$\label{central_fourth_o4}\frac{-u_{n+3} + 12u_{n+2} - 39u_{n+1} + 56u_n - 39u_{n-1} + 12u_{n-2} - u_{n-3}}{6\Delta x^4}$$ |

--- a/notebooks/intro/matsuno-gill.ipynb
+++ b/notebooks/intro/matsuno-gill.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "source": [
     "## Discretization\n",
-    "The numerical scheme used to solve the equations is a forward-in-time, centered-in-space finite difference method. The steady-state solution of the system will be reached by model convergence after a sufficient number of time steps. Solving for $\\partial / \\partial t$, equation [](#gill_matsuno_base) becomes:\n",
+    "The numerical scheme used to solve the equations is a [forward-in-time](#euler_explicit), [centered-in-space](#central_first_o2) finite difference method. The steady-state solution of the system will be reached by model convergence after a sufficient number of time steps. Solving for $\\partial / \\partial t$, equation [](#gill_matsuno_base) becomes:\n",
     "\n",
     "$$\n",
     "\\label{gill_matsuno_discretization_u}\n",


### PR DESCRIPTION
Fixed inconsistencies in notations for the finite difference equations (made everything subscript, time has superscript).

Also added references to the numerical schemes used in the discretization section of the Gill-Matsuno notebook.

<img width="740" height="172" alt="Screenshot 2025-08-08 at 13 54 54" src="https://github.com/user-attachments/assets/5622697a-9ee0-425c-b41d-81495ce78fa6" />
